### PR TITLE
Feature/mdrmine homepage customisation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     - image: 'circleci/clojure:openjdk-8-lein-2.9.1-node-browsers'
   intermine_exec:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:current
     environment:
       BLUEGENES_DEFAULT_SERVICE_ROOT: "http://localhost:9999/biotestmine"
       BLUEGENES_DEFAULT_MINE_NAME: Biotestmine
@@ -52,7 +52,8 @@ jobs:
     - run: sudo apt-get update -y
     - run: sudo apt-get install -y libgconf-2-4
     - run: pyenv versions
-    - run: pyenv global 3.8.5
+    - run: pyenv global 3.13.0
+    - run: pip3 install "setuptools<81"
     - run: pip3 install intermine-boot
     - restore_cache:
         keys:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,8 @@ RUN npm install;
 RUN lein uberjar;
 
 EXPOSE 5000
-CMD ["java", "-jar", "target/bluegenes.jar"]
+# Reset WORKDIR to / (matching the original distroless-based Dockerfile) so relative
+# paths BlueGenes resolves at runtime (e.g. "./tools") match compose.yaml's mount
+# target of /tools, instead of resolving under /bluegenes and never touching it.
+WORKDIR /
+CMD ["java", "-jar", "/bluegenes/target/bluegenes.jar"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # BlueGenes
 
+> **This is [ECRIN](https://ecrin.org)'s fork of [intermine/bluegenes](https://github.com/intermine/bluegenes)**, maintained for the [MDRMine](https://github.com/ecrin-github/mdrmine) project's frontend. It carries MDRMine-specific customisations on top of upstream BlueGenes (see `git log` for what's changed).
+
 CircleCI: [![CircleCI](https://circleci.com/gh/intermine/bluegenes.svg?style=svg)](https://circleci.com/gh/intermine/bluegenes)
 
 _An InterMine Web-based GUI_

--- a/cypress/integration/main_page_test.js
+++ b/cypress/integration/main_page_test.js
@@ -30,13 +30,6 @@ describe("Main page test", function() {
         cy.url().should("include", "/templates");
     });
 
-    it("can access regions tab from the navigation bar", function() {
-        cy.get("#bluegenes-main-nav").within(() => {
-            cy.contains("Regions").click();
-        });
-        cy.url().should("include", "/regions");
-    });
-
     it("can access query builder tab from the navigation bar", function() {
         cy.get("#bluegenes-main-nav").within(() => {
             cy.contains("Query Builder").click();

--- a/cypress/integration/pr_test.js
+++ b/cypress/integration/pr_test.js
@@ -137,7 +137,7 @@ describe("UI Test", function() {
   it("Perform a region search using existing example", function() {
     cy.server();
     cy.route("POST", "*/service/query/results").as("getData");
-    cy.contains("Regions").click();
+    cy.visit("/biotestmine/regions");
     cy.contains("Show Example").click();
     cy.get(".region-text > .form-control").should("not.be.empty");
     cy.get("button")

--- a/less/components/home.less
+++ b/less/components/home.less
@@ -57,14 +57,16 @@
 
     .section {
         margin-top: @spacer*4;
-        margin-bottom: @spacer*5;
+        margin-bottom: 0;
 
         & > [class*='col-'] {
-            margin-bottom: @spacer*2.2;
+            margin-bottom: 0;
         }
 
-        h1, h2 {
+        h1, h2, h3, .h1, .h2, .h3 {
             color: @branding-color-secondary;
+            margin-top: 20px;
+            margin-bottom: 0;
         }
 
         .cta-block {

--- a/less/components/navbar.less
+++ b/less/components/navbar.less
@@ -331,6 +331,20 @@
                 }
             }
 
+            .floating-label-field label {
+                color: inherit;
+                font-size: 13px;
+                font-weight: 500;
+                // Override the light background added for the feedback form
+                // (meant to mask a border there); the nav has no such border
+                // and its own dark background, so no mask is needed here.
+                // !important is needed because components/ui/inputs.less
+                // (which sets that background on the floated/focused state)
+                // is imported after this file, and both selectors have the
+                // same specificity, so it would otherwise win.
+                background: transparent !important;
+            }
+
             .dropdown-menu {
                 min-width: 40vw;
             }

--- a/less/components/ui/inputs.less
+++ b/less/components/ui/inputs.less
@@ -1,5 +1,48 @@
 @import "../../variables";
 
+// Floating label: the label sits over the input/textarea like a placeholder
+// by default, then floats above it on focus/input so it's never hidden
+// (accessibility: a screen reader user or a sighted user typing should
+// always be able to see/hear what the field is for).
+.floating-label-field {
+    position: relative;
+
+    label {
+        position: absolute;
+        left: 0;
+        top: 50%;
+        margin: 0;
+        padding: 0 3px;
+        font-size: 1em;
+        opacity: 0.6;
+        pointer-events: none;
+        transform: translateY(-50%);
+        transform-origin: left top;
+        transition: transform 0.15s ease-out, opacity 0.15s ease-out,
+                    font-size 0.15s ease-out;
+        white-space: nowrap;
+    }
+
+    // Textarea text starts at the top rather than being vertically
+    // centered, so its resting label position needs to match.
+    textarea + label {
+        top: 1.75em;
+        transform: none;
+    }
+
+    input:focus + label,
+    input:not(:placeholder-shown) + label,
+    textarea:focus + label,
+    textarea:not(:placeholder-shown) + label {
+        font-size: 0.75em;
+        opacity: 0.9;
+        // Move the label fully clear of the field's top border, and give it
+        // a background so the border doesn't visually cut through the text.
+        transform: translateY(-2.3em);
+        background: @body-background-color;
+    }
+}
+
 .toggle-show-password {
     position: relative;
 

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -281,10 +281,6 @@
     [:a {:href (route/href ::route/templates)}
      "Templates"]]
    [:li.primary-nav
-    {:class (classes :regions-panel large-screen?)}
-    [:a {:href (route/href ::route/regions)}
-     "Regions"]]
-   [:li.primary-nav
     {:class (classes :querybuilder-panel large-screen?)}
     [:a {:href (route/href ::route/querybuilder)}
      "Query\u00A0Builder"]]

--- a/src/cljs/bluegenes/components/search/typeahead.cljs
+++ b/src/cljs/bluegenes/components/search/typeahead.cljs
@@ -87,7 +87,8 @@
   (reagent/create-class
    (let [results     (subscribe [:suggestion-results])
          error       (subscribe [:suggestion-error])
-         search-term (subscribe [:search-term])]
+         search-term (subscribe [:search-term])
+         input-id    (str (gensym "search-term-"))]
      {:component-did-mount
       (fn [e]
         (let [node (dom/dom-node e)]
@@ -97,11 +98,14 @@
               (dommy/listen! :blur (fn [] (dommy/remove-class! node :open))))))
       :reagent-render
       (fn []
-        [:div.dropdown
+        [:div.dropdown.floating-label-field
          [:input.typeahead-search
           {:type         "text"
+           :id           input-id
            :value        @search-term
-           :placeholder  "Search for any term"
+           ;; A non-empty placeholder is required for the `:placeholder-shown`
+           ;; CSS pseudo-class (used to float the label below) to work.
+           :placeholder  " "
            :on-change    (fn [e] (dispatch [:bounce-search (oget e :target :value)]))
            ;; Navigate to the main search results page if the user presses enter.
            :on-key-press (fn [e] (monitor-enter-key e))
@@ -114,6 +118,7 @@
                            ;; suggestions, it would be an empty vector.)
                            (when (nil? @results)
                              (dispatch [:bounce-search (oget e :target :value)])))}]
+         [:label {:for input-id} "Search for any term"]
          ;; The following icon button is hidden by default, so use CSS if you want it!
          [:svg.icon.icon-search.search-button
           {:on-click #(navigate-to-full-results)}

--- a/src/cljs/bluegenes/events/blog.cljs
+++ b/src/cljs/bluegenes/events/blog.cljs
@@ -2,12 +2,14 @@
   (:require [re-frame.core :refer [reg-event-db reg-event-fx]]
             [bluegenes.effects :as fx]))
 
-(def default-rss "https://intermineorg.wordpress.com/feed/")
+;; MDRMine has no blog of its own; so we will be using the url of the github releases atom feed for the project as a default
+;; and gives genuinely useful "what's new" content.
+(def default-rss "https://github.com/ecrin-github/mdrmine/releases.atom")
 
 (defn get-rss-from-db [db]
   (if-let [rss (not-empty (get-in db [:mines (:current-mine db) :rss]))]
     rss
-    default-rss))
+    default-rss)),
 
 (reg-event-fx
  ::fetch-rss

--- a/src/cljs/bluegenes/pages/home/views.cljs
+++ b/src/cljs/bluegenes/pages/home/views.cljs
@@ -262,16 +262,24 @@
                      [:h3 "Thank you!"]
                      [:p "Your feedback has been submitted."]]
            [:div.col-xs-12.col-sm-10.col-sm-offset-1.col-md-8.col-md-offset-2.feedback
-            [:input.form-control
-             {:type "email"
-              :placeholder "Your email (optional)"
-              :value @email*
-              :on-change #(reset! email* (oget % :target :value))}]
-            [:textarea#feedbackform.form-control
-             {:placeholder "Your feedback here"
-              :rows 5
-              :value @text*
-              :on-change #(reset! text* (oget % :target :value))}]
+            [:div.floating-label-field
+             [:input.form-control
+              {:type "email"
+               :id "feedback-email"
+               ;; A non-empty placeholder is required for the
+               ;; `:placeholder-shown` CSS pseudo-class (used to float the
+               ;; label above) to work.
+               :placeholder " "
+               :value @email*
+               :on-change #(reset! email* (oget % :target :value))}]
+             [:label {:for "feedback-email"} "Your email (optional)"]]
+            [:div.floating-label-field
+             [:textarea#feedbackform.form-control
+              {:placeholder " "
+               :rows 5
+               :value @text*
+               :on-change #(reset! text* (oget % :target :value))}]
+             [:label {:for "feedbackform"} "Your feedback here"]]
             [:button.btn.btn-block
              {:on-click #(dispatch [:home/submit-feedback @email* @text*])}
              "Submit"]

--- a/src/cljs/bluegenes/pages/home/views.cljs
+++ b/src/cljs/bluegenes/pages/home/views.cljs
@@ -123,7 +123,7 @@
             :role "button"}
     :body [:p [:strong "Contact us"] " with problems, comments, suggestions and any other queries."]}
    {:label "What's new"
-    :props {:href (or @(subscribe [:current-mine/news]) "https://intermineorg.wordpress.com/")
+    :props {:href (or @(subscribe [:current-mine/news]) "https://github.com/ecrin-github/mdrmine")
             :target "_blank"}
     :body [latest-news]}
    {:label "Cite us"
@@ -135,14 +135,18 @@
   (let [custom-cta @(subscribe [:home/custom-cta])
         cta (if (seq custom-cta)
               (map convert-custom-cta custom-cta)
-              (default-cta))]
-    (into [:div.row.section.grid] ;; Without grid class the 3rd row won't be on the same row.
+              (default-cta))
+        mine-name @(subscribe [:current-mine-human-name])]
+    [:<>
+     [:div.row.section
+      [:div.col-xs-12 [:h2.text-center (str "Explore " mine-name)]]]
+     (into [:div.row.section.grid] ;; Without grid class the 3rd row won't be on the same row.
            ;; This isn't official bootstrap, so I can only imagine Gridlex is messing with things.
-          (for [[index {:keys [label props body]}] (map-indexed vector cta)]
-            [:div.col-xs-12.col-sm-5.cta-block
-             {:class (when (odd? index) :col-sm-offset-2)}
-             [:a.btn.btn-home props label]
-             body]))))
+           (for [[index {:keys [label props body]}] (map-indexed vector cta)]
+             [:div.col-xs-12.col-sm-5.cta-block
+              {:class (when (odd? index) :col-sm-offset-2)}
+              [:a.btn.btn-home props label]
+              body]))]))
 
 (defn mine-selector-filter []
   (let [all-neighbourhoods @(subscribe [:home/all-registry-mine-neighbourhoods])


### PR DESCRIPTION
Related to ecrin-github/mdrmine#55

- Removed the "Regions" link from the main navigation
- Fixed the "What's new" blog link, which pointed to the default IntermineOrg blog, to point to MDRMine's GitHub releases feed instead
- Added a dynamic, mine-branded "Explore {mine}" heading to the homepage call-to-action section
- Fixed the CircleCI setup_intermine job, which had drifted out of date (stale machine image, unavailable Python version, missing pkg_resources dependency)
- Updated Cypress tests to match the removed Regions nav link