### PR TITLE
Fix/report page body scroll

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -52,7 +52,6 @@ body {
 }
 
 #app,
-body,
 html {
   height: 100%;
 }

--- a/less/site.less
+++ b/less/site.less
@@ -56,11 +56,14 @@ html {
   height: 100%;
 }
 
-body,
-html {
+body {
   // Belt-and-braces: stop any single element that refuses to shrink/wrap
   // (a common flexbox gotcha) from ever forcing horizontal scroll on the
   // whole page.
+  //
+  // This must not also be set on html: overflow-x on the root element is
+  // a known Chromium/Blink bug trigger that breaks position:sticky for
+  // every descendant on the page, regardless of any other CSS.
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
Fixes the report page's sidebar: it stopped updating which section was active while scrolling, and the sticky TOC/right panel didn't stay stuck. Both came from overflow-x:hidden on body/html, added by the earlier home page responsiveness fix — it breaks position:sticky on the root html element.